### PR TITLE
Add function 800EEA58 to Mario Party 3 (U) symbols

### DIFF
--- a/src/symbols/MarioParty3U.sym.js
+++ b/src/symbols/MarioParty3U.sym.js
@@ -2454,6 +2454,11 @@ export default [{
       name: "GetPlayerPlacement",
       desc: "A0=player_index" },
 {
+      addr: 2148461144, // 0x800EEA58
+      type: "code",
+      name: "GetPlayerPlacementAtEndOfGame",
+      desc: "A0=player_index" },
+{
       addr: 2148475184, // 0x800F2130
       type: "code",
       name: "GetCurrentPlayerIndex" },


### PR DESCRIPTION
While researching Item AI use, I've found a variant of function GetPlayerPlacement/800EE9C0 in address 800EEA58 which functions similarly except the placement returned is based as if the game ended prior to placement.

This means that if Bonus Stars are enabled, then the placement returned for a given player index is based as if the Bonus Stars are awarded to the players prior to checking for placement.

This new function functions exactly like GetPlayerPlacement/800EE9C0 if Bonus Stars are disabled, though.